### PR TITLE
Add velocity PID 

### DIFF
--- a/src/main/java/frc/robot/utils/logging/io/pidmotor/MockSparkMaxPidMotorIo.java
+++ b/src/main/java/frc/robot/utils/logging/io/pidmotor/MockSparkMaxPidMotorIo.java
@@ -24,6 +24,10 @@ public class MockSparkMaxPidMotorIo extends MockSparkMaxIo implements SparkMaxPi
     }
 
     @Override
+    public void setPidVelocity(double velocity) {
+    }
+
+    @Override
     public void setPid(double pidP, double pidI, double pidD) {
     }
 

--- a/src/main/java/frc/robot/utils/logging/io/pidmotor/RealSparkMaxPidMotorIo.java
+++ b/src/main/java/frc/robot/utils/logging/io/pidmotor/RealSparkMaxPidMotorIo.java
@@ -27,6 +27,11 @@ public class RealSparkMaxPidMotorIo extends RealSparkMaxIo implements SparkMaxPi
     }
 
     @Override
+    public void setPidVelocity(double velocity) {
+        pidMotor.setPidVelocity(velocity);
+    }
+
+    @Override
     public void setPid(double pidP, double pidI, double pidD) {
         pidMotor.setPid(pidP, pidI, pidD);
     }

--- a/src/main/java/frc/robot/utils/logging/io/pidmotor/SparkMaxPidConfig.java
+++ b/src/main/java/frc/robot/utils/logging/io/pidmotor/SparkMaxPidConfig.java
@@ -18,7 +18,7 @@ public class SparkMaxPidConfig {
     private double d = DEFAULT_D;
     private double iZone = DEFAULT_IZONE;
     private double ff = DEFAULT_FF;
-    private int currentLimit; // TODO: SHould this be set to 40 as a default?
+    private int currentLimit = 20;
     /**
      * This is the cruise velocity for the MAX_MOTION config.
      */

--- a/src/main/java/frc/robot/utils/logging/io/pidmotor/SparkMaxPidMotor.java
+++ b/src/main/java/frc/robot/utils/logging/io/pidmotor/SparkMaxPidMotor.java
@@ -29,8 +29,8 @@ public class SparkMaxPidMotor {
     // The built-in PID controller
     private final SparkClosedLoopController pidController;
 
-    // The desired motor position
-    private double setPosition = 0.0;
+    // The desired motor setpoint (for position, velocity, etc.)
+    private double setPoint = 0.0;
 
     /**
      * Constructor using reasonable default values
@@ -107,18 +107,28 @@ public class SparkMaxPidMotor {
 
     /**
      * Set the desired position using the relative encoder as a reference.
-     * TODO: Change to SetPoint in name and docs, so can be used for VelocityPid
      *
      * @param position the desired motor position
      */
     public void setPidPosition(double position) {
         SparkBase.ControlType type = pidConfig.getUsesMaxMotion() ? SparkBase.ControlType.kMAXMotionPositionControl : SparkBase.ControlType.kPosition;
         pidController.setSetpoint(position, type);
-        this.setPosition = position;
+        this.setPoint = position;
     }
 
-    public double getPidPosition() {
-        return setPosition;
+    /**
+     * Set the desired velocity (in RPM) using the relative encoder as a reference.
+     *
+     * @param velocity the desired motor velocity
+     */
+    public void setPidVelocity(double velocity) {
+        SparkBase.ControlType type = pidConfig.getUsesMaxMotion() ? SparkBase.ControlType.kMAXMotionVelocityControl : SparkBase.ControlType.kVelocity;
+        pidController.setSetpoint(velocity, type);
+        this.setPoint = velocity;
+    }
+
+    public double getPidSetPoint() {
+        return setPoint;
     }
 
     public void setPid(double pidP, double pidI, double pidD) {

--- a/src/main/java/frc/robot/utils/logging/io/pidmotor/SparkMaxPidMotorIo.java
+++ b/src/main/java/frc/robot/utils/logging/io/pidmotor/SparkMaxPidMotorIo.java
@@ -23,6 +23,14 @@ public interface SparkMaxPidMotorIo extends SparkMaxIo {
     void setPidPosition(double position);
 
     /**
+     * Set PID velocity.
+     * Set the velocity (in RPM) for the PidMotor to get to.
+     *
+     * @param velocity the position (in rotations) to drive to
+     */
+    void setPidVelocity(double velocity);
+
+    /**
      * Set new PID values for the PidMotor.
      * This will replace the existing PID values with the nerw ones
      * @param pidP P value to set


### PR DESCRIPTION
This PR adds velocity PID capability to the SparkMaxPidMotor and SparkMaxPidMotorIo.
Note that the PID values are not tuned yet - followup PR will introduce reasonable defaults for Position and for Velocity PIDs.
